### PR TITLE
Demo walk through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ out/
 target/
 node_modules/
 Thumbs.db
+.sdkmanrc
+settings.json

--- a/graalpy/graalpy-jbang-qrcode/README.md
+++ b/graalpy/graalpy-jbang-qrcode/README.md
@@ -22,7 +22,7 @@ sdk install jbang
 To start the demo, run:
 
 ```bash
-jbang run QRCodeMaker.java "Hello from GraalPy!"
+jbang run qrcode.java "Hello from GraalPy!"
 ```
 
 ## Implementation Details

--- a/graalwasm/graalwasm-micronaut-photon/pom.xml
+++ b/graalwasm/graalwasm-micronaut-photon/pom.xml
@@ -96,11 +96,6 @@
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <buildArg>-march=native</buildArg>
-                    </buildArgs>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/graalwasm/graalwasm-spring-boot-photon/pom.xml
+++ b/graalwasm/graalwasm-spring-boot-photon/pom.xml
@@ -71,11 +71,6 @@
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <buildArg>-march=native</buildArg>
-                    </buildArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Made a couple of tweaks:
1. `-march=compatibility` in the WASM Photon demo pom.xml files
2. Fixed name of file to run with `jbang` README instructions.