### PR TITLE
Ensure G1 GC is only enabled on Linux.

### DIFF
--- a/graalwasm/graalwasm-micronaut-photon/pom.xml
+++ b/graalwasm/graalwasm-micronaut-photon/pom.xml
@@ -194,7 +194,7 @@
             <id>enable-g1gc</id>
             <activation>
                 <os>
-                    <family>unix</family>
+                    <name>Linux</name>
                 </os>
             </activation>
             <build>

--- a/graalwasm/graalwasm-spring-boot-photon/pom.xml
+++ b/graalwasm/graalwasm-spring-boot-photon/pom.xml
@@ -135,7 +135,7 @@
             <id>enable-g1gc</id>
             <activation>
                 <os>
-                    <family>unix</family>
+                    <name>Linux</name>
                 </os>
             </activation>
             <build>


### PR DESCRIPTION
See https://maciejwalkowiak.com/blog/activate-maven-profile-by-operating-system/