### PR TITLE
Update Gradle and Maven GraalPy plugin usages for 24.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules/
 Thumbs.db
 .sdkmanrc
 settings.json
+graalpy/graalpy-javase-guide/python-resources
+**/.mvn/wrapper/maven-wrapper.jar

--- a/graalpy/graalpy-freeze-dependencies-guide/README.md
+++ b/graalpy/graalpy-freeze-dependencies-guide/README.md
@@ -81,13 +81,13 @@ For Maven, add dependency on GraalPy runtime, and configure the GraalPy Maven pl
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
             <version>24.2.0</version>
+            <configuration>
+                <packages> <!-- ① -->
+                    <package>vaderSentiment==3.3.2</package>
+                </packages>
+            </configuration>
             <executions>
                 <execution>
-                    <configuration>
-                        <packages> <!-- ① -->
-                            <package>vaderSentiment==3.3.2</package>
-                        </packages>
-                    </configuration>
                     <goals>
                         <goal>process-graalpy-resources</goal>
                     </goals>
@@ -112,10 +112,6 @@ plugins {
 ```kotlin
 graalPy {
     packages = setOf("vaderSentiment==3.3.2") // ①
-}
-
-dependencies {
-    implementation("org.graalvm.python:python:24.2.0")
 }
 ```
 
@@ -183,18 +179,18 @@ If you use Maven, paste them in the `pom.xml` section of the packages and wrap t
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
             <version>24.2.0</version>
+            <configuration>
+                <packages> <!-- ① -->
+                    <package>vaderSentiment==3.3.2</package>
+                    <package>certifi==2024.8.30</package>
+                    <package>charset-normalizer==3.1.0</package>
+                    <package>idna==3.8</package>
+                    <package>requests==2.32.3</package>
+                    <package>urllib3==2.2.2</package>
+                </packages>
+            </configuration>
             <executions>
                 <execution>
-                    <configuration>
-                        <packages> <!-- ① -->
-                            <package>vaderSentiment==3.3.2</package>
-                            <package>certifi==2024.8.30</package>
-                            <package>charset-normalizer==3.1.0</package>
-                            <package>idna==3.8</package>
-                            <package>requests==2.32.3</package>
-                            <package>urllib3==2.2.2</package>
-                        </packages>
-                    </configuration>
                     <goals>
                         <goal>process-graalpy-resources</goal>
                     </goals>

--- a/graalpy/graalpy-freeze-dependencies-guide/build.gradle.kts
+++ b/graalpy/graalpy-freeze-dependencies-guide/build.gradle.kts
@@ -11,9 +11,6 @@ if ("true".equals(System.getProperty("no.transitive.dependencies"))) {
     graalPy {
         packages = setOf("vaderSentiment==3.3.2") // ①
     }
-    dependencies {
-        implementation("org.graalvm.python:python:24.2.0")
-    }
 } else {
     // The default profile shows the end result: all our transitive
     // dependencies are explicitly pinned to a specific version.
@@ -26,9 +23,6 @@ if ("true".equals(System.getProperty("no.transitive.dependencies"))) {
             "requests==2.32.3",
             "urllib3==2.2.2"
         )
-    }
-    dependencies {
-        implementation("org.graalvm.python:python:24.2.0")
     }
 }
 

--- a/graalpy/graalpy-freeze-dependencies-guide/pom.xml
+++ b/graalpy/graalpy-freeze-dependencies-guide/pom.xml
@@ -45,18 +45,18 @@
                         <groupId>org.graalvm.python</groupId>
                         <artifactId>graalpy-maven-plugin</artifactId>
                         <version>24.2.0</version>
+                        <configuration>
+                            <packages> <!-- ① -->
+                                <package>vaderSentiment==3.3.2</package>
+                                <package>certifi==2024.8.30</package>
+                                <package>charset-normalizer==3.1.0</package>
+                                <package>idna==3.8</package>
+                                <package>requests==2.32.3</package>
+                                <package>urllib3==2.2.2</package>
+                            </packages>
+                        </configuration>
                         <executions>
                             <execution>
-                                <configuration>
-                                    <packages> <!-- ① -->
-                                        <package>vaderSentiment==3.3.2</package>
-                                        <package>certifi==2024.8.30</package>
-                                        <package>charset-normalizer==3.1.0</package>
-                                        <package>idna==3.8</package>
-                                        <package>requests==2.32.3</package>
-                                        <package>urllib3==2.2.2</package>
-                                    </packages>
-                                </configuration>
                                 <goals>
                                     <goal>process-graalpy-resources</goal>
                                 </goals>
@@ -81,13 +81,13 @@
                         <groupId>org.graalvm.python</groupId>
                         <artifactId>graalpy-maven-plugin</artifactId>
                         <version>24.2.0</version>
+                        <configuration>
+                            <packages> <!-- ① -->
+                                <package>vaderSentiment==3.3.2</package>
+                            </packages>
+                        </configuration>
                         <executions>
                             <execution>
-                                <configuration>
-                                    <packages> <!-- ① -->
-                                        <package>vaderSentiment==3.3.2</package>
-                                    </packages>
-                                </configuration>
                                 <goals>
                                     <goal>process-graalpy-resources</goal>
                                 </goals>

--- a/graalpy/graalpy-javase-guide/build.gradle.kts
+++ b/graalpy/graalpy-javase-guide/build.gradle.kts
@@ -5,8 +5,7 @@ plugins {
 
 graalPy {
     packages = setOf("qrcode==7.4.2") // ①
-    pythonHome { includes = setOf(); excludes = setOf(".*") } // ②
-    pythonResourcesDirectory = file("${project.projectDir}/python-resources") // ③
+    externalDirectory = file("${project.projectDir}/python-resources") // ②
 }
 
 repositories {
@@ -14,11 +13,6 @@ repositories {
     maven {
         url = uri("https://repo.maven.apache.org/maven2/")
     }
-}
-
-dependencies {
-  implementation("org.graalvm.python:python:24.2.0") // ①
-  implementation("org.graalvm.python:python-embedding:24.2.0") // ③
 }
 
 group = "org.example"

--- a/graalpy/graalpy-javase-guide/pom.xml
+++ b/graalpy/graalpy-javase-guide/pom.xml
@@ -35,23 +35,16 @@
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
         <version>24.2.0</version>
+        <configuration>
+          <packages> <!-- ① -->
+            <package>qrcode==7.4.2</package>
+          </packages>
+          <externalDirectory> <!-- ② -->
+            ${project.basedir}/python-resources
+          </externalDirectory>
+        </configuration>
         <executions>
           <execution>
-            <configuration>
-              <packages> <!-- ① -->
-                <package>qrcode==7.4.2</package>
-              </packages>
-              <pythonHome> <!-- ② -->
-                <includes>
-                </includes>
-                <excludes>
-                  <exclude>.*</exclude>
-                </excludes>
-              </pythonHome>
-              <pythonResourcesDirectory> <!-- ③ -->
-                ${project.basedir}/python-resources
-              </pythonResourcesDirectory>
-            </configuration>
             <goals>
               <goal>process-graalpy-resources</goal>
             </goals>

--- a/graalpy/graalpy-javase-guide/src/main/java/org/example/App.java
+++ b/graalpy/graalpy-javase-guide/src/main/java/org/example/App.java
@@ -12,11 +12,12 @@ import javax.swing.*;
 
 public class App {
     public static void main(String[] args) throws IOException {
-        if (System.getProperty("graalpy.resources") == null) {
+        String path = System.getProperty("graalpy.resources");
+        if (path == null || path.isBlank() || path.equals("null")) {
             System.err.println("Please provide 'graalpy.resources' system property.");
             System.exit(1);
         }
-        try (var context = GraalPy.createPythonContext(System.getProperty("graalpy.resources"))) { // ①
+        try (var context = GraalPy.createPythonContext(path)) { // ①
             QRCode qrCode = context.eval("python", "import qrcode; qrcode").as(QRCode.class); // ②
             IO io = context.eval("python", "import io; io").as(IO.class);
 

--- a/graalpy/graalpy-javase-guide/src/main/java/org/example/GraalPy.java
+++ b/graalpy/graalpy-javase-guide/src/main/java/org/example/GraalPy.java
@@ -15,15 +15,13 @@ public class GraalPy {
     static VirtualFileSystem vfs;
 
     public static Context createPythonContext(String pythonResourcesDirectory) { // ①
-        return GraalPyResources.contextBuilder(Path.of(pythonResourcesDirectory))
-            .option("python.PythonHome", "") // ②
-            .build();
+        return GraalPyResources.contextBuilder(Path.of(pythonResourcesDirectory)).build();
     }
 
     public static Context createPythonContextFromResources() {
-        if (vfs == null) { // ③
+        if (vfs == null) { // ②
             vfs = VirtualFileSystem.newBuilder().allowHostIO(VirtualFileSystem.HostIO.READ).build();
         }
-        return GraalPyResources.contextBuilder(vfs).option("python.PythonHome", "").build();
+        return GraalPyResources.contextBuilder(vfs).build();
     }
 }

--- a/graalpy/graalpy-jbang-qrcode/qrcode.java
+++ b/graalpy/graalpy-jbang-qrcode/qrcode.java
@@ -10,6 +10,7 @@
 //DEPS org.graalvm.python:python-embedding:24.2.0
 //DEPS org.graalvm.python:python-embedding-tools:24.2.0
 //DEPS org.graalvm.python:jbang:24.2.0
+//DEPS org.graalvm.truffle:truffle-runtime:24.2.0
 //PIP qrcode==7.4.2
 
 import org.graalvm.python.embedding.utils.GraalPyResources;

--- a/graalpy/graalpy-micronaut-guide/README.md
+++ b/graalpy/graalpy-micronaut-guide/README.md
@@ -63,7 +63,9 @@ public class Application {
 
 ### 4.2 Dependency configuration
 
-Add the required dependencies for GraalPy in the dependency section of the POM or Gradle build script.
+Add the required dependencies for GraalPy in the dependency section of the POM build script.
+For Gradle, the GraalPy Gradle plugin that we will add in the next section will inject the GraalPy
+related dependencies automatically.
 
 `pom.xml`
 ```xml
@@ -86,8 +88,6 @@ Add the required dependencies for GraalPy in the dependency section of the POM o
 
 `build.gradle.kts`
 ```kotlin
-    implementation("org.graalvm.python:python:24.2.0") // ①
-    implementation("org.graalvm.python:python-embedding:24.2.0") // ③
     implementation("io.micronaut.views:micronaut-views-thymeleaf") // ④
 ```
 
@@ -110,22 +110,22 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 `pom.xml`
 ```xml
 <plugin>
-    <groupId>org.graalvm.python</groupId>
-    <artifactId>graalpy-maven-plugin</artifactId>
-    <version>24.2.0</version>
-    <executions>
-        <execution>
-            <configuration>
-                <packages> <!-- ① -->
-                    <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
-                    <package>requests</package> <!-- ③ -->
-                </packages>
-            </configuration>
-            <goals>
-                <goal>process-graalpy-resources</goal>
-            </goals>
-        </execution>
-    </executions>
+  <groupId>org.graalvm.python</groupId>
+  <artifactId>graalpy-maven-plugin</artifactId>
+  <version>24.2.0</version>
+  <configuration>
+    <packages> <!-- ① -->
+      <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
+      <package>requests</package> <!-- ③ -->
+    </packages>
+  </configuration>
+  <executions>
+    <execution>
+      <goals>
+        <goal>process-graalpy-resources</goal>
+      </goals>
+    </execution>
+  </executions>
 </plugin>
 ```
 

--- a/graalpy/graalpy-micronaut-guide/build.gradle.kts
+++ b/graalpy/graalpy-micronaut-guide/build.gradle.kts
@@ -21,8 +21,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.graalvm.python:python:24.2.0") // ①
-    implementation("org.graalvm.python:python-embedding:24.2.0") // ③
     implementation("io.micronaut.views:micronaut-views-thymeleaf") // ④
 
     annotationProcessor("io.micronaut:micronaut-http-validation")

--- a/graalpy/graalpy-micronaut-guide/pom.xml
+++ b/graalpy/graalpy-micronaut-guide/pom.xml
@@ -91,14 +91,14 @@
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
         <version>24.2.0</version>
+        <configuration>
+          <packages> <!-- ① -->
+            <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
+            <package>requests</package> <!-- ③ -->
+          </packages>
+        </configuration>
         <executions>
           <execution>
-            <configuration>
-              <packages> <!-- ① -->
-                <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
-                <package>requests</package> <!-- ③ -->
-              </packages>
-            </configuration>
             <goals>
               <goal>process-graalpy-resources</goal>
             </goals>

--- a/graalpy/graalpy-micronaut-pygal-charts/pom.xml
+++ b/graalpy/graalpy-micronaut-pygal-charts/pom.xml
@@ -93,13 +93,13 @@
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
         <version>${graalpy.version}</version>
+        <configuration>
+          <packages>
+            <package>pygal==3.0.5</package>
+          </packages>
+        </configuration>
         <executions>
           <execution>
-            <configuration>
-              <packages>
-                <package>pygal==3.0.5</package>
-              </packages>
-            </configuration>
             <goals>
               <goal>process-graalpy-resources</goal>
             </goals>

--- a/graalpy/graalpy-native-extensions-guide/README.md
+++ b/graalpy/graalpy-native-extensions-guide/README.md
@@ -87,19 +87,19 @@ You can use the GraalPy plugin to manage Python packages for you.
 
 `pom.xml`
 ```xml
-    <build>
+<build>
     <plugins>
         <plugin>
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
             <version>24.2.0</version>
+            <configuration>
+                <packages> <!-- ① -->
+                    <package>polyleven==0.8</package>
+                </packages>
+            </configuration>
             <executions>
                 <execution>
-                    <configuration>
-                        <packages> <!-- ① -->
-                            <package>polyleven==0.8</package>
-                        </packages>
-                    </configuration>
                     <goals>
                         <goal>process-graalpy-resources</goal>
                     </goals>

--- a/graalpy/graalpy-native-extensions-guide/pom.xml
+++ b/graalpy/graalpy-native-extensions-guide/pom.xml
@@ -36,13 +36,13 @@
                 <groupId>org.graalvm.python</groupId>
                 <artifactId>graalpy-maven-plugin</artifactId>
                 <version>24.2.0</version>
+                <configuration>
+                    <packages> <!-- ① -->
+                        <package>polyleven==0.8</package>
+                    </packages>
+                </configuration>
                 <executions>
                     <execution>
-                        <configuration>
-                            <packages> <!-- ① -->
-                                <package>polyleven==0.8</package>
-                            </packages>
-                        </configuration>
                         <goals>
                             <goal>process-graalpy-resources</goal>
                         </goals>

--- a/graalpy/graalpy-openai-starter/pom.xml
+++ b/graalpy/graalpy-openai-starter/pom.xml
@@ -66,28 +66,28 @@
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
         <version>${graalpy.version}</version>
+        <configuration>
+          <packages>
+            <package>annotated-types==0.7.0</package>
+            <package>anyio==4.6.0</package>
+            <package>certifi==2024.8.30</package>
+            <package>distro==1.9.0</package>
+            <package>h11==0.14.0</package>
+            <package>hpy==0.9.0</package>
+            <package>httpcore==1.0.5</package>
+            <package>httpx==0.27.2</package>
+            <package>idna==3.10</package>
+            <package>jiter==0.5.0</package> <!-- uses a native extension -->
+            <package>openai==1.47.1</package>
+            <package>pydantic==2.4.2</package>
+            <package>pydantic_core==2.10.1</package> <!-- uses a native extension -->
+            <package>sniffio==1.3.1</package>
+            <package>tqdm==4.66.5</package>
+            <package>typing_extensions==4.12.2</package>
+          </packages>
+        </configuration>
         <executions>
           <execution>
-            <configuration>
-              <packages>
-                <package>annotated-types==0.7.0</package>
-                <package>anyio==4.6.0</package>
-                <package>certifi==2024.8.30</package>
-                <package>distro==1.9.0</package>
-                <package>h11==0.14.0</package>
-                <package>hpy==0.9.0</package>
-                <package>httpcore==1.0.5</package>
-                <package>httpx==0.27.2</package>
-                <package>idna==3.10</package>
-                <package>jiter==0.5.0</package> <!-- uses a native extension -->
-                <package>openai==1.47.1</package>
-                <package>pydantic==2.4.2</package>
-                <package>pydantic_core==2.10.1</package> <!-- uses a native extension -->
-                <package>sniffio==1.3.1</package>
-                <package>tqdm==4.66.5</package>
-                <package>typing_extensions==4.12.2</package>
-              </packages>
-            </configuration>
             <goals>
               <goal>process-graalpy-resources</goal>
             </goals>

--- a/graalpy/graalpy-spring-boot-guide/README.md
+++ b/graalpy/graalpy-spring-boot-guide/README.md
@@ -55,7 +55,9 @@ public class DemoApplication {
 
 ### 4.2 Dependency configuration
 
-Add the required dependencies for GraalPy in the dependency section of the POM or Gradle build script.
+Add the required dependencies for GraalPy in the dependency section of the POM build script.
+For Gradle, the GraalPy Gradle plugin that we will add in the next section will inject these
+dependencies automatically.
 
 `pom.xml`
 ```xml
@@ -70,12 +72,6 @@ Add the required dependencies for GraalPy in the dependency section of the POM o
   <artifactId>python-embedding</artifactId> <!-- ③ -->
   <version>24.2.0</version>
 </dependency>
-```
-
-`build.gradle`
-```groovy
-  implementation 'org.graalvm.python:python:24.2.0' // ①
-  implementation 'org.graalvm.python:python-embedding:24.2.0' // ③
 ```
 
 ❶ The `python` dependency is a meta-package that transitively depends on all resources and libraries to run GraalPy.
@@ -98,14 +94,14 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
     <groupId>org.graalvm.python</groupId>
     <artifactId>graalpy-maven-plugin</artifactId>
     <version>24.2.0</version>
+    <configuration>
+        <packages> <!-- ① -->
+            <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
+            <package>requests</package> <!-- ③ -->
+        </packages>
+    </configuration>
     <executions>
         <execution>
-            <configuration>
-                <packages> <!-- ① -->
-                    <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
-                    <package>requests</package> <!-- ③ -->
-                </packages>
-            </configuration>
             <goals>
                 <goal>process-graalpy-resources</goal>
             </goals>

--- a/graalpy/graalpy-spring-boot-guide/build.gradle
+++ b/graalpy/graalpy-spring-boot-guide/build.gradle
@@ -28,8 +28,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.graalvm.python:python:24.2.0' // ①
-  implementation 'org.graalvm.python:python-embedding:24.2.0' // ③
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/graalpy/graalpy-spring-boot-guide/pom.xml
+++ b/graalpy/graalpy-spring-boot-guide/pom.xml
@@ -64,14 +64,14 @@
                 <groupId>org.graalvm.python</groupId>
                 <artifactId>graalpy-maven-plugin</artifactId>
                 <version>24.2.0</version>
+                <configuration>
+                    <packages> <!-- ① -->
+                        <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
+                        <package>requests</package> <!-- ③ -->
+                    </packages>
+                </configuration>
                 <executions>
                     <execution>
-                        <configuration>
-                            <packages> <!-- ① -->
-                                <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
-                                <package>requests</package> <!-- ③ -->
-                            </packages>
-                        </configuration>
                         <goals>
                             <goal>process-graalpy-resources</goal>
                         </goals>

--- a/graalpy/graalpy-spring-boot-pygal-charts/pom.xml
+++ b/graalpy/graalpy-spring-boot-pygal-charts/pom.xml
@@ -68,13 +68,13 @@
                 <groupId>org.graalvm.python</groupId>
                 <artifactId>graalpy-maven-plugin</artifactId>
                 <version>${graalpy.version}</version>
+                <configuration>
+                    <packages>
+                        <package>pygal==3.0.5</package>
+                    </packages>
+                </configuration>
                 <executions>
                     <execution>
-                        <configuration>
-                            <packages>
-                                <package>pygal==3.0.5</package>
-                            </packages>
-                        </configuration>
                         <goals>
                             <goal>process-graalpy-resources</goal>
                         </goals>


### PR DESCRIPTION
* removed GraalPy(-embedding) dependencies in Gradle build scripts, they are injected automatically now
* removed the obsoleted options for Python stdlib embedding in VFS
* removed the `.option("python.PythonHome", "")` workaround when not embedding Python stdlib in VFS
* moved the `<configuration>` section to be child of `<plugin>` and not in `<executions>` in all pom.xml scripts. This will be necessary for the "pip freeze" feature in the next release -- the task cannot access the configuration when it is part of a specific execution.
* renamed now deprecated `pythonResourcesDirectory` -> `externalDirectory`