### PR TITLE
Build Photon from source and improve demos.

### DIFF
--- a/.github/workflows/graalwasm-micronaut-photon.yml
+++ b/.github/workflows/graalwasm-micronaut-photon.yml
@@ -25,6 +25,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Package 'graalwasm-micronaut-photon'
         run: |
           cd graalwasm/graalwasm-micronaut-photon

--- a/.github/workflows/graalwasm-spring-boot-photon.yml
+++ b/.github/workflows/graalwasm-spring-boot-photon.yml
@@ -25,6 +25,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Package 'graalwasm-spring-boot-photon'
         run: |
           cd graalwasm/graalwasm-spring-boot-photon

--- a/graalwasm/graalwasm-micronaut-photon/build-photon.sh
+++ b/graalwasm/graalwasm-micronaut-photon/build-photon.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025, Oracle and/or its affiliates.
+#
+# Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.org/license/UPL.
+#
+
+set -o errexit
+set -o nounset
+
+PHOTON_COMMIT="e95eccf886897c2efe8c2461fae9c6bf1375ff49"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ -d "${SCRIPT_DIR}/target/classes/photon" ]]; then
+    echo "Photon already built from source. Nothing to do."
+    exit 0
+fi
+
+function ensure_command() {
+    local cmd=$1
+    if ! command -v "${cmd}" > /dev/null; then
+        cat <<EOF
+${cmd} not found.
+
+Please install '${cmd}' on your system and restart.
+EOF
+        fail ""
+    fi
+}
+
+ensure_command "curl"
+ensure_command "unzip"
+ensure_command "wasm-pack"
+
+echo "Building Photon from source..."
+
+mkdir -p target/photon
+pushd target/photon > /dev/null
+
+if [[ ! -f photon-src.zip ]]; then
+    curl -sL -o photon-src.zip "https://github.com/silvia-odwyer/photon/archive/${PHOTON_COMMIT}.zip"
+fi
+if [[ ! -d "photon-${PHOTON_COMMIT}" ]]; then
+    unzip -q photon-src.zip
+fi
+pushd "photon-${PHOTON_COMMIT}" > /dev/null
+
+wasm-pack build --release --target bundler --out-name photon --out-dir "${SCRIPT_DIR}"/target/classes/photon ./crate
+
+echo "Copying example image..."
+
+cp crate/examples/input_images/daisies_fuji.jpg "${SCRIPT_DIR}"/target/classes
+
+popd > /dev/null
+popd > /dev/null

--- a/graalwasm/graalwasm-micronaut-photon/pom.xml
+++ b/graalwasm/graalwasm-micronaut-photon/pom.xml
@@ -14,10 +14,6 @@
     </parent>
     <properties>
         <graal.languages.version>24.2.2</graal.languages.version>
-        <photon.version>0.1.30</photon.version>
-        <photon.download.url>
-            https://raw.githubusercontent.com/fineshopdesign/cf-wasm/refs/tags/%40cf-wasm/satori%40${photon.version}/packages/photon/src/lib
-        </photon.download.url>
         <packaging>jar</packaging>
         <jdk.version>24</jdk.version>
         <release.version>24</release.version>
@@ -101,51 +97,23 @@
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>2.0.2</version>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
-                        <id>download-photon-js</id>
+                        <id>build-photon</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>download-single</goal>
+                            <goal>exec</goal>
                         </goals>
-                        <configuration>
-                            <url>${photon.download.url}</url>
-                            <fromFile>photon_rs.js</fromFile>
-                            <toDir>${project.build.outputDirectory}/photon</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-photon-wasm</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>${photon.download.url}</url>
-                            <fromFile>photon_rs_bg.wasm</fromFile>
-                            <toDir>${project.build.outputDirectory}/photon</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-example-image</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>
-                                https://raw.githubusercontent.com/silvia-odwyer/photon/d084f6842c29bbb4838bf97bc98fd8c45b892cba/crate/examples/input_images
-                            </url>
-                            <fromFile>daisies_fuji.jpg</fromFile>
-                            <toDir>${project.build.outputDirectory}</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <executable>bash</executable>
+                    <arguments>
+                        <argument>build-photon.sh</argument>
+                    </arguments>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/Photon.java
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/Photon.java
@@ -9,7 +9,7 @@ package com.example;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.ByteSequence;
 
-public record Photon(Value module, Value imageContent) {
+public record Photon(Value module, Uint8Array imageContent) {
 
     boolean implementsEffect(String effectName) {
         return module.hasMember(effectName);
@@ -20,14 +20,23 @@ public record Photon(Value module, Value imageContent) {
     }
 
     PhotonImage createImage() {
-        return module.getMember("PhotonImage").invokeMember("new_from_byteslice", imageContent).as(PhotonImage.class);
+        PhotonImage photonImage = module.getMember("PhotonImage").as(PhotonImage.class);
+        return photonImage.new_from_byteslice(imageContent);
     }
 
     public interface PhotonImage {
         void free();
+
+        Uint8Array get_bytes();
+
+        PhotonImage new_from_byteslice(Uint8Array imageContent);
+    }
+
+    public interface Uint8Array {
+        ByteSequence buffer();
     }
 
     public static byte[] toByteArray(PhotonImage photonImage) {
-        return Value.asValue(photonImage).invokeMember("get_bytes").getMember("buffer").as(ByteSequence.class).toByteArray();
+        return photonImage.get_bytes().buffer().toByteArray();
     }
 }

--- a/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/Photon.java
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/Photon.java
@@ -9,7 +9,7 @@ package com.example;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.ByteSequence;
 
-public record Photon(Value module, Uint8Array imageContent) {
+public record Photon(Value module, PhotonImage photonImage, Uint8Array imageContent) {
 
     boolean implementsEffect(String effectName) {
         return module.hasMember(effectName);
@@ -20,7 +20,6 @@ public record Photon(Value module, Uint8Array imageContent) {
     }
 
     PhotonImage createImage() {
-        PhotonImage photonImage = module.getMember("PhotonImage").as(PhotonImage.class);
         return photonImage.new_from_byteslice(imageContent);
     }
 
@@ -36,7 +35,7 @@ public record Photon(Value module, Uint8Array imageContent) {
         ByteSequence buffer();
     }
 
-    public static byte[] toByteArray(PhotonImage photonImage) {
-        return photonImage.get_bytes().buffer().toByteArray();
+    public static byte[] toByteArray(PhotonImage image) {
+        return image.get_bytes().buffer().toByteArray();
     }
 }

--- a/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/PhotonPool.java
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/PhotonPool.java
@@ -6,6 +6,7 @@
 
 package com.example;
 
+import com.example.Photon.Uint8Array;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.core.io.ResourceResolver;
 import jakarta.annotation.PreDestroy;
@@ -24,15 +25,14 @@ public class PhotonPool {
     private final BlockingQueue<Photon> photons;
 
     PhotonPool(ResourceResolver resourceResolve) throws IOException {
-        URL photonModuleURL = resourceResolve.getResource("classpath:photon/photon_rs.js").get();
+        URL photonModuleURL = resourceResolve.getResource("classpath:photon/photon.js").get();
         Source photonSource = Source.newBuilder("js", photonModuleURL).mimeType("application/javascript+module").build();
-        byte[] wasmBytes = resourceResolve.getResourceAsStream("classpath:photon/photon_rs_bg.wasm").get().readAllBytes();
         byte[] imageBytes = resourceResolve.getResourceAsStream("classpath:daisies_fuji.jpg").get().readAllBytes();
 
         int maxThreads = Runtime.getRuntime().availableProcessors();
         photons = new LinkedBlockingQueue<>(maxThreads);
         for (int i = 0; i < maxThreads; i++) {
-            photons.add(createPhoton(sharedEngine, photonSource, wasmBytes, imageBytes));
+            photons.add(createPhoton(sharedEngine, photonSource, imageBytes));
         }
     }
 
@@ -53,25 +53,21 @@ public class PhotonPool {
         sharedEngine.close();
     }
 
-    private static Photon createPhoton(Engine engine, Source photonSource, Object wasmBytes, Object imageBytes) {
-        org.graalvm.polyglot.Context context = org.graalvm.polyglot.Context.newBuilder("js", "wasm")
+    private static Photon createPhoton(Engine engine, Source photonSource, Object imageBytes) {
+        var context = org.graalvm.polyglot.Context.newBuilder("js", "wasm")
                 .engine(engine)
                 .allowAllAccess(true)
                 .allowExperimentalOptions(true)
-                .option("js.webassembly", "true")
                 .option("js.esm-eval-returns-exports", "true")
+                .option("js.text-encoding", "true")
+                .option("js.webassembly", "true")
                 .build();
 
-        // Get Uint8Array class from JavaScript
-        Value uint8Array = context.eval("js", "Uint8Array");
         // Load Photon module and initialize with wasm content
         Value photonModule = context.eval(photonSource);
-        // Create Uint8Array with wasm bytes
-        Value wasmContent = uint8Array.newInstance(wasmBytes);
-        // Initialize Photon module with wasm content
-        photonModule.invokeMember("default", wasmContent);
+
         // Create Uint8Array with image bytes
-        Value imageContent = uint8Array.newInstance(imageBytes);
+        Uint8Array imageContent = context.getBindings("js").getMember("Uint8Array").newInstance(imageBytes).as(Uint8Array.class);
 
         return new Photon(photonModule, imageContent);
     }

--- a/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/PhotonPool.java
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/java/com/example/PhotonPool.java
@@ -6,6 +6,7 @@
 
 package com.example;
 
+import com.example.Photon.PhotonImage;
 import com.example.Photon.Uint8Array;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.core.io.ResourceResolver;
@@ -66,9 +67,12 @@ public class PhotonPool {
         // Load Photon module and initialize with wasm content
         Value photonModule = context.eval(photonSource);
 
+        // Fetch PhotonImage class
+        PhotonImage photonImage = photonModule.getMember("PhotonImage").as(PhotonImage.class);
+
         // Create Uint8Array with image bytes
         Uint8Array imageContent = context.getBindings("js").getMember("Uint8Array").newInstance(imageBytes).as(Uint8Array.class);
 
-        return new Photon(photonModule, imageContent);
+        return new Photon(photonModule, photonImage, imageContent);
     }
 }

--- a/graalwasm/graalwasm-micronaut-photon/src/main/resources/META-INF/native-image/com.example/demo/proxy-config.json
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/resources/META-INF/native-image/com.example/demo/proxy-config.json
@@ -1,7 +1,0 @@
-[
-  {
-    "interfaces": [
-      "com.example.Photon$PhotonImage"
-    ]
-  }
-]

--- a/graalwasm/graalwasm-micronaut-photon/src/main/resources/META-INF/native-image/com.example/demo/reachability-metadata.json
+++ b/graalwasm/graalwasm-micronaut-photon/src/main/resources/META-INF/native-image/com.example/demo/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "type": {
+        "proxy": [
+          "com.example.Photon$PhotonImage"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "com.example.Photon$Uint8Array"
+        ]
+      }
+    }
+  ]
+}

--- a/graalwasm/graalwasm-micronaut-photon/src/test/java/com/example/DemoTest.java
+++ b/graalwasm/graalwasm-micronaut-photon/src/test/java/com/example/DemoTest.java
@@ -19,7 +19,7 @@ class DemoTest {
 
     @Test
     void testEffectEquality() {
-        for (String effectName : new String[]{"default", "grayscale", "flipv", "fliph"}) {
+        for (String effectName : new String[]{"grayscale", "flipv", "fliph", "obsidian"}) {
             byte[] imageContent1 = photonService.processImage(effectName);
             byte[] imageContent2 = photonService.processImage(effectName);
             Assertions.assertArrayEquals(imageContent1, imageContent2, "Two processed images not identical when effect '%s' is used".formatted(effectName));

--- a/graalwasm/graalwasm-spring-boot-photon/README.md
+++ b/graalwasm/graalwasm-spring-boot-photon/README.md
@@ -23,7 +23,6 @@ To start the demo, simply run:
 When the demo runs, open http://localhost:8080/ in a browser.
 To apply a specific effect, navigate to `http://localhost:8080/photo/<effect name>` (e.g., http://localhost:8080/photo/colorize).
 
-
 To compile the application with GraalVM Native Image, run:
 
 ```bash

--- a/graalwasm/graalwasm-spring-boot-photon/build-photon.sh
+++ b/graalwasm/graalwasm-spring-boot-photon/build-photon.sh
@@ -8,7 +8,7 @@
 set -o errexit
 set -o nounset
 
-PHOTON_COMMIT="e95eccf886897c2efe8c2461fae9c6bf1375ff49"
+PHOTON_COMMIT="e4ef13d602828b171e04bf232741d63621dfec14"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/graalwasm/graalwasm-spring-boot-photon/build-photon.sh
+++ b/graalwasm/graalwasm-spring-boot-photon/build-photon.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025, Oracle and/or its affiliates.
+#
+# Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.org/license/UPL.
+#
+
+set -o errexit
+set -o nounset
+
+PHOTON_COMMIT="e95eccf886897c2efe8c2461fae9c6bf1375ff49"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ -d "${SCRIPT_DIR}/target/classes/photon" ]]; then
+    echo "Photon already built from source. Nothing to do."
+    exit 0
+fi
+
+function ensure_command() {
+    local cmd=$1
+    if ! command -v "${cmd}" > /dev/null; then
+        cat <<EOF
+${cmd} not found.
+
+Please install '${cmd}' on your system and restart.
+EOF
+        fail ""
+    fi
+}
+
+ensure_command "curl"
+ensure_command "unzip"
+ensure_command "wasm-pack"
+
+echo "Building Photon from source..."
+
+mkdir -p target/photon
+pushd target/photon > /dev/null
+
+if [[ ! -f photon-src.zip ]]; then
+    curl -sL -o photon-src.zip "https://github.com/silvia-odwyer/photon/archive/${PHOTON_COMMIT}.zip"
+fi
+if [[ ! -d "photon-${PHOTON_COMMIT}" ]]; then
+    unzip -q photon-src.zip
+fi
+pushd "photon-${PHOTON_COMMIT}" > /dev/null
+
+wasm-pack build --release --target bundler --out-name photon --out-dir "${SCRIPT_DIR}"/target/classes/photon ./crate
+
+echo "Copying example image..."
+
+cp crate/examples/input_images/daisies_fuji.jpg "${SCRIPT_DIR}"/target/classes
+
+popd > /dev/null
+popd > /dev/null

--- a/graalwasm/graalwasm-spring-boot-photon/pom.xml
+++ b/graalwasm/graalwasm-spring-boot-photon/pom.xml
@@ -28,9 +28,6 @@
     </scm>
     <properties>
         <graal.languages.version>24.2.2</graal.languages.version>
-        <photon.download.url>
-            https://raw.githubusercontent.com/fineshopdesign/cf-wasm/dca69477657fe80e36989f1fe7dcc17700d81ee2/packages/photon/src/lib
-        </photon.download.url>
         <java.version>21</java.version>
     </properties>
     <dependencies>
@@ -81,51 +78,23 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>2.0.2</version>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
-                        <id>download-photon-js</id>
+                        <id>build-photon</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>download-single</goal>
+                            <goal>exec</goal>
                         </goals>
-                        <configuration>
-                            <url>${photon.download.url}</url>
-                            <fromFile>photon_rs.js</fromFile>
-                            <toDir>${project.build.outputDirectory}/photon</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-photon-wasm</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>${photon.download.url}</url>
-                            <fromFile>photon_rs_bg.wasm</fromFile>
-                            <toDir>${project.build.outputDirectory}/photon</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-example-image</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>
-                                https://raw.githubusercontent.com/silvia-odwyer/photon/d084f6842c29bbb4838bf97bc98fd8c45b892cba/crate/examples/input_images
-                            </url>
-                            <fromFile>daisies_fuji.jpg</fromFile>
-                            <toDir>${project.build.outputDirectory}</toDir>
-                            <skipIfExists>true</skipIfExists>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <executable>bash</executable>
+                    <arguments>
+                        <argument>build-photon.sh</argument>
+                    </arguments>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/Photon.java
+++ b/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/Photon.java
@@ -11,7 +11,7 @@ import org.graalvm.polyglot.io.ByteSequence;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 
-public record Photon(Value module, Uint8Array imageContent) {
+public record Photon(Value module, PhotonImage photonImage, Uint8Array imageContent) {
 
     boolean implementsEffect(String effectName) {
         return module.hasMember(effectName);
@@ -22,7 +22,6 @@ public record Photon(Value module, Uint8Array imageContent) {
     }
 
     PhotonImage createImage() {
-        PhotonImage photonImage = module.getMember("PhotonImage").as(PhotonImage.class);
         return photonImage.new_from_byteslice(imageContent);
     }
 
@@ -38,14 +37,7 @@ public record Photon(Value module, Uint8Array imageContent) {
         ByteSequence buffer();
     }
 
-    public static byte[] toByteArray(PhotonImage photonImage) {
-        return photonImage.get_bytes().buffer().toByteArray();
-    }
-
-    static class PhotonRuntimeHints implements RuntimeHintsRegistrar {
-        @Override
-        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-            hints.proxies().registerJdkProxy(PhotonImage.class);
-        }
+    public static byte[] toByteArray(PhotonImage image) {
+        return image.get_bytes().buffer().toByteArray();
     }
 }

--- a/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
+++ b/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
@@ -70,10 +70,13 @@ public class PhotonPool {
         // Load Photon module and initialize with wasm content
         Value photonModule = context.eval(photonSource);
 
+        // Fetch PhotonImage class
+        PhotonImage photonImage = photonModule.getMember("PhotonImage").as(PhotonImage.class);
+
         // Create Uint8Array with image bytes
         Uint8Array imageContent = context.getBindings("js").getMember("Uint8Array").newInstance(imageBytes).as(Uint8Array.class);
 
-        return new Photon(photonModule, imageContent);
+        return new Photon(photonModule, photonImage, imageContent);
     }
 
     static class PhotonPoolRuntimeHints implements RuntimeHintsRegistrar {

--- a/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
+++ b/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
@@ -82,7 +82,9 @@ public class PhotonPool {
             hints.resources()
                     .registerPattern("photon/*")
                     .registerPattern("daisies_fuji.jpg");
-            hints.proxies().registerJdkProxy(PhotonImage.class);
+            hints.proxies()
+                    .registerJdkProxy(PhotonImage.class)
+                    .registerJdkProxy(Uint8Array.class);
         }
     }
 }

--- a/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
+++ b/graalwasm/graalwasm-spring-boot-photon/src/main/java/com/example/demo/PhotonPool.java
@@ -7,6 +7,7 @@
 package com.example.demo;
 
 import com.example.demo.Photon.PhotonImage;
+import com.example.demo.Photon.Uint8Array;
 import jakarta.annotation.PreDestroy;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
@@ -29,14 +30,13 @@ public class PhotonPool {
     private final BlockingQueue<Photon> photons;
 
     PhotonPool() throws IOException {
-        Source photonSource = Source.newBuilder("js", new ClassPathResource("photon/photon_rs.js").getURL()).mimeType("application/javascript+module").build();
-        byte[] wasmBytes = new ClassPathResource("photon/photon_rs_bg.wasm").getContentAsByteArray();
+        Source photonSource = Source.newBuilder("js", new ClassPathResource("photon/photon.js").getURL()).mimeType("application/javascript+module").build();
         byte[] imageBytes = new ClassPathResource("daisies_fuji.jpg").getContentAsByteArray();
 
         int maxThreads = Runtime.getRuntime().availableProcessors();
         photons = new LinkedBlockingQueue<>(maxThreads);
         for (int i = 0; i < maxThreads; i++) {
-            photons.add(createPhoton(sharedEngine, photonSource, wasmBytes, imageBytes));
+            photons.add(createPhoton(sharedEngine, photonSource, imageBytes));
         }
     }
 
@@ -57,25 +57,21 @@ public class PhotonPool {
         sharedEngine.close();
     }
 
-    private static Photon createPhoton(Engine engine, Source photonSource, byte[] wasmBytes, byte[] imageBytes) {
+    private static Photon createPhoton(Engine engine, Source photonSource, Object imageBytes) {
         Context context = Context.newBuilder("js", "wasm")
                 .engine(engine)
                 .allowAllAccess(true)
                 .allowExperimentalOptions(true)
-                .option("js.webassembly", "true")
                 .option("js.esm-eval-returns-exports", "true")
+                .option("js.text-encoding", "true")
+                .option("js.webassembly", "true")
                 .build();
 
-        // Get Uint8Array class from JavaScript
-        Value uint8Array = context.eval("js", "Uint8Array");
         // Load Photon module and initialize with wasm content
         Value photonModule = context.eval(photonSource);
-        // Create Uint8Array with wasm bytes
-        Value wasmContent = uint8Array.newInstance(wasmBytes);
-        // Initialize Photon module with wasm content
-        photonModule.invokeMember("default", wasmContent);
+
         // Create Uint8Array with image bytes
-        Value imageContent = uint8Array.newInstance(imageBytes);
+        Uint8Array imageContent = context.getBindings("js").getMember("Uint8Array").newInstance(imageBytes).as(Uint8Array.class);
 
         return new Photon(photonModule, imageContent);
     }

--- a/graalwasm/graalwasm-spring-boot-photon/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/graalwasm/graalwasm-spring-boot-photon/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -19,7 +19,7 @@ class DemoApplicationTests {
 
     @Test
     void testEffectEquality() {
-        for (String effectName : new String[]{"default", "grayscale", "flipv", "fliph"}) {
+        for (String effectName : new String[]{"grayscale", "flipv", "fliph", "obsidian"}) {
             byte[] imageContent1 = photonService.processImage(effectName);
             byte[] imageContent2 = photonService.processImage(effectName);
             Assertions.assertArrayEquals(imageContent1, imageContent2, "Two processed images not identical when effect '%s' is used".formatted(effectName));


### PR DESCRIPTION
Build Photon from source and use the generated code to initialize its JS binding with its Wasm module. The latter requires `24.2.2` or later for native due to an "Unsupported URI scheme resource" error.