### PR TITLE
Upgrade all demos and guides to 24.2.1 and GraalVM for JDK 24.0.1.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "month"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "month"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "month"

--- a/.github/workflows/espresso-continuations.yml
+++ b/.github/workflows/espresso-continuations.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Espresso
-        run: curl -sL -o $RUNNER_TEMP/espresso-linux-amd64.tar.gz https://gds.oracle.com/download/espresso/archive/espresso-java21-24.2.0-linux-amd64.tar.gz
+        run: curl -sL -o $RUNNER_TEMP/espresso-linux-amd64.tar.gz https://gds.oracle.com/download/espresso/archive/espresso-java21-24.2.1-linux-amd64.tar.gz
       - uses: actions/setup-java@v4
         with:
           java-version: '21'

--- a/.github/workflows/graaljs-maven-webpack-guide.yml
+++ b/.github/workflows/graaljs-maven-webpack-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graaljs-starter.yml
+++ b/.github/workflows/graaljs-starter.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-custom-venv-guide.yml
+++ b/.github/workflows/graalpy-custom-venv-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-freeze-dependencies-guide.yml
+++ b/.github/workflows/graalpy-freeze-dependencies-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-javase-guide.yml
+++ b/.github/workflows/graalpy-javase-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-jbang-qrcode.yml
+++ b/.github/workflows/graalpy-jbang-qrcode.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run 'graalpy-jbang-qrcode' demo

--- a/.github/workflows/graalpy-jython-guide.yml
+++ b/.github/workflows/graalpy-jython-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-micronaut-guide.yml
+++ b/.github/workflows/graalpy-micronaut-guide.yml
@@ -38,7 +38,7 @@ jobs:
           kill $mnpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
@@ -78,7 +78,7 @@ jobs:
           kill $mnpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'gradle'

--- a/.github/workflows/graalpy-micronaut-multithreaded.yml
+++ b/.github/workflows/graalpy-micronaut-multithreaded.yml
@@ -39,7 +39,7 @@ jobs:
           kill $mnpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
@@ -81,7 +81,7 @@ jobs:
           kill $mnpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'gradle'

--- a/.github/workflows/graalpy-micronaut-pygal-charts.yml
+++ b/.github/workflows/graalpy-micronaut-pygal-charts.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-native-extensions-guide.yml
+++ b/.github/workflows/graalpy-native-extensions-guide.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-openai-starter.yml
+++ b/.github/workflows/graalpy-openai-starter.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-script-debug.yml
+++ b/.github/workflows/graalpy-script-debug.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-spring-boot-guide.yml
+++ b/.github/workflows/graalpy-spring-boot-guide.yml
@@ -38,7 +38,7 @@ jobs:
           kill $sbpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
@@ -78,7 +78,7 @@ jobs:
           kill $sbpid
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'gradle'

--- a/.github/workflows/graalpy-spring-boot-pygal-charts.yml
+++ b/.github/workflows/graalpy-spring-boot-pygal-charts.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalpy-starter.yml
+++ b/.github/workflows/graalpy-starter.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalwasm-embed-c-code-guide.yml
+++ b/.github/workflows/graalwasm-embed-c-code-guide.yml
@@ -30,7 +30,7 @@ jobs:
           ./emsdk activate latest
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalwasm-micronaut-photon.yml
+++ b/.github/workflows/graalwasm-micronaut-photon.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalwasm-spring-boot-photon.yml
+++ b/.github/workflows/graalwasm-spring-boot-photon.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/.github/workflows/graalwasm-starter.yml
+++ b/.github/workflows/graalwasm-starter.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.0'
+          java-version: '24.0.1'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'

--- a/espresso/espresso-continuations/README.md
+++ b/espresso/espresso-continuations/README.md
@@ -5,7 +5,7 @@ Each time it runs, the program increments a counter, displays the updated value,
 
 ## Preparation
 
-Install [Espresso 24.2.0](https://www.graalvm.org/latest/reference-manual/espresso/) and set the value of `JAVA_HOME` accordingly.
+Install [Espresso 24.2.1](https://www.graalvm.org/latest/reference-manual/espresso/) and set the value of `JAVA_HOME` accordingly.
 
 ## Run the Application
 

--- a/espresso/espresso-continuations/pom.xml
+++ b/espresso/espresso-continuations/pom.xml
@@ -11,7 +11,7 @@
   <url>https://www.example.com</url>
 
   <properties>
-    <espresso.version>24.2.0</espresso.version>
+    <espresso.version>24.2.1</espresso.version>
     <serializer>java</serializer>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>

--- a/graaljs/graaljs-maven-webpack-guide/README.md
+++ b/graaljs/graaljs-maven-webpack-guide/README.md
@@ -43,13 +43,13 @@ Add the required dependencies for GraalJS in the `<dependencies>` section of the
 <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>polyglot</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
 </dependency>
 
 <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>js</artifactId> <!-- ② -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ③ -->
 </dependency>
 <!-- </dependencies> -->

--- a/graaljs/graaljs-maven-webpack-guide/pom.xml
+++ b/graaljs/graaljs-maven-webpack-guide/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>js</artifactId>
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type>
     </dependency>
 

--- a/graaljs/graaljs-starter/README.md
+++ b/graaljs/graaljs-starter/README.md
@@ -8,7 +8,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application Using Maven

--- a/graaljs/graaljs-starter/build.gradle.kts
+++ b/graaljs/graaljs-starter/build.gradle.kts
@@ -9,8 +9,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.graalvm.polyglot:polyglot:24.2.0")
-    implementation("org.graalvm.polyglot:js:24.2.0")
+    implementation("org.graalvm.polyglot:polyglot:24.2.1")
+    implementation("org.graalvm.polyglot:js:24.2.1")
 
     // Use JUnit Jupiter for testing.
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")

--- a/graaljs/graaljs-starter/pom.xml
+++ b/graaljs/graaljs-starter/pom.xml
@@ -31,12 +31,12 @@
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId> 
-        <version>24.2.0</version>
+        <version>24.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>js</artifactId>
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type>
     </dependency>
 

--- a/graalpy/graalpy-custom-venv-guide/README.md
+++ b/graalpy/graalpy-custom-venv-guide/README.md
@@ -54,14 +54,14 @@ Add the required dependencies for GraalPy in the `<dependencies>` section of the
   <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>python</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ② -->
   </dependency>
 
   <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>polyglot</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
   </dependency>
 </dependencies>
 ```

--- a/graalpy/graalpy-custom-venv-guide/pom.xml
+++ b/graalpy/graalpy-custom-venv-guide/pom.xml
@@ -17,14 +17,14 @@
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>python</artifactId> <!-- ① -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type> <!-- ② -->
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/graalpy/graalpy-freeze-dependencies-guide/README.md
+++ b/graalpy/graalpy-freeze-dependencies-guide/README.md
@@ -68,7 +68,7 @@ For Maven, add dependency on GraalPy runtime, and configure the GraalPy Maven pl
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>python</artifactId>
-        <version>24.2.0</version>
+        <version>24.2.1</version>
         <type>pom</type>
     </dependency>
 ```
@@ -80,7 +80,7 @@ For Maven, add dependency on GraalPy runtime, and configure the GraalPy Maven pl
         <plugin>
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <configuration>
                 <packages> <!-- ① -->
                     <package>vaderSentiment==3.3.2</package>
@@ -104,7 +104,7 @@ For Gradle, add the GraalPy plugin, configure it, and add the dependency on the 
 ```kotlin
 plugins {
     application
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
 }
 ```
 
@@ -178,7 +178,7 @@ If you use Maven, paste them in the `pom.xml` section of the packages and wrap t
         <plugin>
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <configuration>
                 <packages> <!-- ① -->
                     <package>vaderSentiment==3.3.2</package>

--- a/graalpy/graalpy-freeze-dependencies-guide/build.gradle.kts
+++ b/graalpy/graalpy-freeze-dependencies-guide/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     application
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
 }
 
 // To make the paths of this reference solution (without 'app' subdirectory for sources)
@@ -34,7 +34,7 @@ repositories {
 }
 
 // This dependency is necessary only for the example Java code, not for building and running pip freeze:
-dependencies.add("implementation", "org.graalvm.python:python-embedding:24.2.0")
+dependencies.add("implementation", "org.graalvm.python:python-embedding:24.2.1")
 
 group = "org.example"
 version = "1.0-SNAPSHOT"

--- a/graalpy/graalpy-freeze-dependencies-guide/pom.xml
+++ b/graalpy/graalpy-freeze-dependencies-guide/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>
             <artifactId>python</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <type>pom</type>
         </dependency>
 
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.graalvm.python</groupId>
             <artifactId>python-embedding</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
         </dependency>
     </dependencies>
 
@@ -44,7 +44,7 @@
                     <plugin>
                         <groupId>org.graalvm.python</groupId>
                         <artifactId>graalpy-maven-plugin</artifactId>
-                        <version>24.2.0</version>
+                        <version>24.2.1</version>
                         <configuration>
                             <packages> <!-- ① -->
                                 <package>vaderSentiment==3.3.2</package>
@@ -80,7 +80,7 @@
                     <plugin>
                         <groupId>org.graalvm.python</groupId>
                         <artifactId>graalpy-maven-plugin</artifactId>
-                        <version>24.2.0</version>
+                        <version>24.2.1</version>
                         <configuration>
                             <packages> <!-- ① -->
                                 <package>vaderSentiment==3.3.2</package>

--- a/graalpy/graalpy-javase-guide/README.md
+++ b/graalpy/graalpy-javase-guide/README.md
@@ -62,14 +62,14 @@ dependencies automatically.
   <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>python</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ② -->
   </dependency>
 
   <dependency>
     <groupId>org.graalvm.python</groupId>
     <artifactId>python-embedding</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
   </dependency>
 </dependencies>
 ```
@@ -93,7 +93,7 @@ You can use the GraalPy plugins for Maven or Gradle to manage Python packages fo
      <plugin>
        <groupId>org.graalvm.python</groupId>
        <artifactId>graalpy-maven-plugin</artifactId>
-       <version>24.2.0</version>
+       <version>24.2.1</version>
        <configuration>
          <packages> <!-- ① -->
            <package>qrcode==7.4.2</package>
@@ -118,7 +118,7 @@ You can use the GraalPy plugins for Maven or Gradle to manage Python packages fo
 ```kotlin
 plugins {
     application
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
 }
 
 graalPy {
@@ -135,7 +135,7 @@ In this case, we install the `qrcode` package and pin it to version `7.4.2`.
 Omit this section if you want to include the Python packages into the Java resources (and, for example, ship them in the Jar).
 [Later in the Java code](#external-or-embedded-python-code-java) we can configure the GraalPy runtime to load the package from the filesystem or from resources.
 
-**Note** that due to a bug in the 24.2.0 version of the `org.graalvm.python` plugin for **Gradle** you need to include a resource.
+**Note** that due to a bug in the 24.2.1 version of the `org.graalvm.python` plugin for **Gradle** you need to include a resource.
 A simple workaround is to add a `src/main/resources/META-INF/MANIFEST.MF`:
 ```
 Manifest-Version: 1.0

--- a/graalpy/graalpy-javase-guide/build.gradle.kts
+++ b/graalpy/graalpy-javase-guide/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     application
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
 }
 
 graalPy {

--- a/graalpy/graalpy-javase-guide/pom.xml
+++ b/graalpy/graalpy-javase-guide/pom.xml
@@ -18,14 +18,14 @@
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>python</artifactId> <!-- ① -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type> <!-- ② -->
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python-embedding</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
   </dependencies>
 
@@ -34,7 +34,7 @@
       <plugin>
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
-        <version>24.2.0</version>
+        <version>24.2.1</version>
         <configuration>
           <packages> <!-- ① -->
             <package>qrcode==7.4.2</package>

--- a/graalpy/graalpy-jbang-qrcode/README.md
+++ b/graalpy/graalpy-jbang-qrcode/README.md
@@ -8,7 +8,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 Afterward, [install `jbang`](https://www.jbang.dev/download/), for with:

--- a/graalpy/graalpy-jbang-qrcode/qrcode.java
+++ b/graalpy/graalpy-jbang-qrcode/qrcode.java
@@ -4,13 +4,13 @@
  * Licensed under the Universal Permissive License v 1.0 as shown at https://opensource.org/license/UPL.
  */
 
-//DEPS org.graalvm.python:python-language:24.2.0
-//DEPS org.graalvm.python:python-launcher:24.2.0
-//DEPS org.graalvm.python:python-resources:24.2.0
-//DEPS org.graalvm.python:python-embedding:24.2.0
-//DEPS org.graalvm.python:python-embedding-tools:24.2.0
-//DEPS org.graalvm.python:jbang:24.2.0
-//DEPS org.graalvm.truffle:truffle-runtime:24.2.0
+//DEPS org.graalvm.python:python-language:24.2.1
+//DEPS org.graalvm.python:python-launcher:24.2.1
+//DEPS org.graalvm.python:python-resources:24.2.1
+//DEPS org.graalvm.python:python-embedding:24.2.1
+//DEPS org.graalvm.python:python-embedding-tools:24.2.1
+//DEPS org.graalvm.python:jbang:24.2.1
+//DEPS org.graalvm.truffle:truffle-runtime:24.2.1
 //PIP qrcode==7.4.2
 
 import org.graalvm.python.embedding.utils.GraalPyResources;

--- a/graalpy/graalpy-jython-guide/README.md
+++ b/graalpy/graalpy-jython-guide/README.md
@@ -115,14 +115,14 @@ Add the required dependencies for GraalPy in the `<dependencies>` section of the
   <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>python</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ② -->
   </dependency>
 
   <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>polyglot</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
   </dependency>
 ```
 

--- a/graalpy/graalpy-jython-guide/pom.xml
+++ b/graalpy/graalpy-jython-guide/pom.xml
@@ -24,13 +24,13 @@
       <dependency>
           <groupId>org.graalvm.polyglot</groupId>
           <artifactId>python</artifactId> <!-- ① -->
-          <version>24.2.0</version>
+          <version>24.2.1</version>
           <type>pom</type> <!-- ② -->
       </dependency>
       <dependency>
           <groupId>org.graalvm.polyglot</groupId>
           <artifactId>polyglot</artifactId> <!-- ③ -->
-          <version>24.2.0</version>
+          <version>24.2.1</version>
       </dependency>
   </dependencies>
 </project>

--- a/graalpy/graalpy-micronaut-guide/README.md
+++ b/graalpy/graalpy-micronaut-guide/README.md
@@ -72,13 +72,13 @@ related dependencies automatically.
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python</artifactId> <!-- ① -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
   <type>pom</type> <!-- ② -->
 </dependency>
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python-embedding</artifactId> <!-- ③ -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
 </dependency>
 <dependency>
     <groupId>io.micronaut.views</groupId>
@@ -112,7 +112,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 <plugin>
   <groupId>org.graalvm.python</groupId>
   <artifactId>graalpy-maven-plugin</artifactId>
-  <version>24.2.0</version>
+  <version>24.2.1</version>
   <configuration>
     <packages> <!-- ① -->
       <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
@@ -132,7 +132,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 `build.gradle.kts`
 ```
 plugins {
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
     // ...
 ```
 

--- a/graalpy/graalpy-micronaut-guide/build.gradle.kts
+++ b/graalpy/graalpy-micronaut-guide/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
     // ...
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("io.micronaut.application") version "4.4.2"

--- a/graalpy/graalpy-micronaut-guide/pom.xml
+++ b/graalpy/graalpy-micronaut-guide/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python</artifactId> <!-- ① -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type> <!-- ② -->
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python-embedding</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
     <dependency>
         <groupId>io.micronaut.views</groupId>
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
-        <version>24.2.0</version>
+        <version>24.2.1</version>
         <configuration>
           <packages> <!-- ① -->
             <package>vader-sentiment==3.2.1.1</package> <!-- ② -->

--- a/graalpy/graalpy-micronaut-multithreaded/README.md
+++ b/graalpy/graalpy-micronaut-multithreaded/README.md
@@ -72,13 +72,13 @@ For Gradle, the GraalPy Gradle plugin that we will add in the next section will 
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python</artifactId> <!-- ① -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
   <type>pom</type> <!-- ② -->
 </dependency>
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python-embedding</artifactId> <!-- ③ -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 <plugin>
   <groupId>org.graalvm.python</groupId>
   <artifactId>graalpy-maven-plugin</artifactId>
-  <version>24.2.0</version>
+  <version>24.2.1</version>
   <configuration>
     <packages> <!-- ① -->
       <package>numpy==1.26.4</package> <!-- ② -->
@@ -155,7 +155,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 `build.gradle.kts`
 ```
 plugins {
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
     // ...
 ```
 

--- a/graalpy/graalpy-micronaut-multithreaded/build.gradle.kts
+++ b/graalpy/graalpy-micronaut-multithreaded/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
     // ...
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("io.micronaut.application") version "4.4.2"

--- a/graalpy/graalpy-micronaut-multithreaded/pom.xml
+++ b/graalpy/graalpy-micronaut-multithreaded/pom.xml
@@ -34,13 +34,13 @@
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python</artifactId> <!-- ① -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type> <!-- ② -->
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python-embedding</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
 
     <dependency>
@@ -136,7 +136,7 @@
       <plugin>
         <groupId>org.graalvm.python</groupId>
         <artifactId>graalpy-maven-plugin</artifactId>
-        <version>24.2.0</version>
+        <version>24.2.1</version>
         <configuration>
           <packages> <!-- ① -->
             <package>numpy==1.26.4</package> <!-- ② -->

--- a/graalpy/graalpy-micronaut-pygal-charts/README.md
+++ b/graalpy/graalpy-micronaut-pygal-charts/README.md
@@ -9,7 +9,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application

--- a/graalpy/graalpy-micronaut-pygal-charts/pom.xml
+++ b/graalpy/graalpy-micronaut-pygal-charts/pom.xml
@@ -13,7 +13,7 @@
     <version>4.6.1</version>
   </parent>
   <properties>
-    <graalpy.version>24.2.0</graalpy.version>
+    <graalpy.version>24.2.1</graalpy.version>
     <packaging>jar</packaging>
     <jdk.version>21</jdk.version>
     <release.version>21</release.version>

--- a/graalpy/graalpy-native-extensions-guide/README.md
+++ b/graalpy/graalpy-native-extensions-guide/README.md
@@ -62,14 +62,14 @@ Add the required dependencies for GraalPy in the dependency section of the POM.
 <dependency>
     <groupId>org.graalvm.python</groupId>
     <artifactId>python</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ② -->
 </dependency>
 
 <dependency>
     <groupId>org.graalvm.python</groupId>
     <artifactId>python-embedding</artifactId> <!-- ③ -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
 </dependency>
 ```
 
@@ -92,7 +92,7 @@ You can use the GraalPy plugin to manage Python packages for you.
         <plugin>
             <groupId>org.graalvm.python</groupId>
             <artifactId>graalpy-maven-plugin</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <configuration>
                 <packages> <!-- ① -->
                     <package>polyleven==0.8</package>

--- a/graalpy/graalpy-native-extensions-guide/pom.xml
+++ b/graalpy/graalpy-native-extensions-guide/pom.xml
@@ -19,14 +19,14 @@
         <dependency>
             <groupId>org.graalvm.python</groupId>
             <artifactId>python</artifactId> <!-- ① -->
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <type>pom</type> <!-- ② -->
         </dependency>
 
         <dependency>
             <groupId>org.graalvm.python</groupId>
             <artifactId>python-embedding</artifactId> <!-- ③ -->
-            <version>24.2.0</version>
+            <version>24.2.1</version>
         </dependency>
     </dependencies>
 
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.graalvm.python</groupId>
                 <artifactId>graalpy-maven-plugin</artifactId>
-                <version>24.2.0</version>
+                <version>24.2.1</version>
                 <configuration>
                     <packages> <!-- ① -->
                         <package>polyleven==0.8</package>

--- a/graalpy/graalpy-openai-starter/README.md
+++ b/graalpy/graalpy-openai-starter/README.md
@@ -8,7 +8,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 This project also requires that an OpenAI API key is set via the `OPENAI_API_KEY` environment variable.

--- a/graalpy/graalpy-openai-starter/build.gradle.kts
+++ b/graalpy/graalpy-openai-starter/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     application
     // Apply GraalPy plugin to add Python packages as dependencies.
-    id("org.graalvm.python") version "24.2.0"
+    id("org.graalvm.python") version "24.2.1"
 }
 
 repositories {

--- a/graalpy/graalpy-openai-starter/pom.xml
+++ b/graalpy/graalpy-openai-starter/pom.xml
@@ -11,7 +11,7 @@
   <url>https://www.example.com</url>
 
   <properties>
-    <graalpy.version>24.2.0</graalpy.version>
+    <graalpy.version>24.2.1</graalpy.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
   </properties>

--- a/graalpy/graalpy-scripts-debug-guide/README.md
+++ b/graalpy/graalpy-scripts-debug-guide/README.md
@@ -40,7 +40,7 @@ If you want to follow along using Maven, you can start with this minimal `pom.xm
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>24.0.0</version>
+      <version>24.0.1</version>
     </dependency>
   </dependencies>
 
@@ -67,7 +67,7 @@ plugins {
 }
 
 javafx {
-    version = "24.0.0"
+    version = "24.0.1"
     modules = listOf("javafx.controls")
 }
 
@@ -87,27 +87,27 @@ Add the required dependencies for GraalPy in the `<dependencies>` section of the
 <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>python</artifactId> <!-- ① -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <type>pom</type> <!-- ② -->
 </dependency>
 <dependency>
     <groupId>org.graalvm.polyglot</groupId>
     <artifactId>polyglot</artifactId> <!-- ③ -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
 </dependency>
 <dependency>
     <groupId>org.graalvm.tools</groupId>
     <artifactId>dap-tool</artifactId> <!-- ④ -->
-    <version>24.2.0</version>
+    <version>24.2.1</version>
 </dependency>
 ```
 
 `build.gradle.kts`
 ```kotlin
 dependencies {
-    implementation("org.graalvm.polyglot:python:24.2.0") // ①
-    implementation("org.graalvm.polyglot:polyglot:24.2.0") // ③
-    implementation("org.graalvm.tools:dap-tool:24.2.0") // ④
+    implementation("org.graalvm.polyglot:python:24.2.1") // ①
+    implementation("org.graalvm.polyglot:polyglot:24.2.1") // ③
+    implementation("org.graalvm.tools:dap-tool:24.2.1") // ④
 }
 ```
 

--- a/graalpy/graalpy-scripts-debug-guide/build.gradle.kts
+++ b/graalpy/graalpy-scripts-debug-guide/build.gradle.kts
@@ -14,9 +14,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.graalvm.polyglot:python:24.2.0") // ①
-    implementation("org.graalvm.polyglot:polyglot:24.2.0") // ③
-    implementation("org.graalvm.tools:dap-tool:24.2.0") // ④
+    implementation("org.graalvm.polyglot:python:24.2.1") // ①
+    implementation("org.graalvm.polyglot:polyglot:24.2.1") // ③
+    implementation("org.graalvm.tools:dap-tool:24.2.1") // ④
 }
 
 application {

--- a/graalpy/graalpy-scripts-debug-guide/pom.xml
+++ b/graalpy/graalpy-scripts-debug-guide/pom.xml
@@ -19,18 +19,18 @@
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>python</artifactId> <!-- ① -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type> <!-- ② -->
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId> <!-- ③ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.graalvm.tools</groupId>
       <artifactId>dap-tool</artifactId> <!-- ④ -->
-      <version>24.2.0</version>
+      <version>24.2.1</version>
     </dependency>
 
     <dependency>

--- a/graalpy/graalpy-spring-boot-guide/README.md
+++ b/graalpy/graalpy-spring-boot-guide/README.md
@@ -64,13 +64,13 @@ dependencies automatically.
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python</artifactId> <!-- ① -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
   <type>pom</type> <!-- ② -->
 </dependency>
 <dependency>
   <groupId>org.graalvm.python</groupId>
   <artifactId>python-embedding</artifactId> <!-- ③ -->
-  <version>24.2.0</version>
+  <version>24.2.1</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 <plugin>
     <groupId>org.graalvm.python</groupId>
     <artifactId>graalpy-maven-plugin</artifactId>
-    <version>24.2.0</version>
+    <version>24.2.1</version>
     <configuration>
         <packages> <!-- ① -->
             <package>vader-sentiment==3.2.1.1</package> <!-- ② -->
@@ -113,7 +113,7 @@ Add the `graalpy-maven-plugin` configuration into the plugins section of the POM
 `build.gradle`
 ```
 plugins {
-  id 'org.graalvm.python' version '24.2.0'
+  id 'org.graalvm.python' version '24.2.1'
   // ...
 ```
 

--- a/graalpy/graalpy-spring-boot-guide/build.gradle
+++ b/graalpy/graalpy-spring-boot-guide/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.graalvm.python' version '24.2.0'
+  id 'org.graalvm.python' version '24.2.1'
   // ...
   id 'java'
   id 'org.springframework.boot' version '3.3.5'

--- a/graalpy/graalpy-spring-boot-guide/pom.xml
+++ b/graalpy/graalpy-spring-boot-guide/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.graalvm.python</groupId>
             <artifactId>python</artifactId> <!-- ① -->
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <type>pom</type> <!-- ② -->
         </dependency>
         <dependency>
             <groupId>org.graalvm.python</groupId>
             <artifactId>python-embedding</artifactId> <!-- ③ -->
-            <version>24.2.0</version>
+            <version>24.2.1</version>
         </dependency>
 
         <dependency>
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.graalvm.python</groupId>
                 <artifactId>graalpy-maven-plugin</artifactId>
-                <version>24.2.0</version>
+                <version>24.2.1</version>
                 <configuration>
                     <packages> <!-- ① -->
                         <package>vader-sentiment==3.2.1.1</package> <!-- ② -->

--- a/graalpy/graalpy-spring-boot-pygal-charts/README.md
+++ b/graalpy/graalpy-spring-boot-pygal-charts/README.md
@@ -9,7 +9,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application

--- a/graalpy/graalpy-spring-boot-pygal-charts/pom.xml
+++ b/graalpy/graalpy-spring-boot-pygal-charts/pom.xml
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <graalpy.version>24.2.0</graalpy.version>
+        <graalpy.version>24.2.1</graalpy.version>
         <java.version>21</java.version>
     </properties>
     <dependencies>

--- a/graalpy/graalpy-starter/README.md
+++ b/graalpy/graalpy-starter/README.md
@@ -8,7 +8,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application Using Maven

--- a/graalpy/graalpy-starter/build.gradle.kts
+++ b/graalpy/graalpy-starter/build.gradle.kts
@@ -9,8 +9,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.graalvm.polyglot:polyglot:24.2.0")
-    implementation("org.graalvm.polyglot:python:24.2.0")
+    implementation("org.graalvm.polyglot:polyglot:24.2.1")
+    implementation("org.graalvm.polyglot:python:24.2.1")
 
     // Use JUnit Jupiter for testing.
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")

--- a/graalpy/graalpy-starter/pom.xml
+++ b/graalpy/graalpy-starter/pom.xml
@@ -11,7 +11,7 @@
   <url>https://www.example.com</url>
 
   <properties>
-    <graalpy.version>24.2.0</graalpy.version>
+    <graalpy.version>24.2.1</graalpy.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
   </properties>

--- a/graalwasm/graalwasm-embed-c-code-guide/README.md
+++ b/graalwasm/graalwasm-embed-c-code-guide/README.md
@@ -33,7 +33,7 @@ Add the following set of dependencies to the `<dependencies>` section of your pr
        <dependency>
            <groupId>org.graalvm.polyglot</groupId>
            <artifactId>polyglot</artifactId>
-           <version>24.2.0</version>
+           <version>24.2.1</version>
        </dependency>
        <!-- </dependencies> -->
        ```
@@ -43,7 +43,7 @@ Add the following set of dependencies to the `<dependencies>` section of your pr
        <dependency>
            <groupId>org.graalvm.polyglot</groupId>
            <artifactId>wasm</artifactId>
-           <version>24.2.0</version>
+           <version>24.2.1</version>
            <type>pom</type>
        </dependency>
        <!-- </dependencies> -->

--- a/graalwasm/graalwasm-embed-c-code-guide/pom.xml
+++ b/graalwasm/graalwasm-embed-c-code-guide/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>
             <artifactId>polyglot</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>
             <artifactId>wasm</artifactId>
-            <version>24.2.0</version>
+            <version>24.2.1</version>
             <type>pom</type>
         </dependency>
 

--- a/graalwasm/graalwasm-micronaut-photon/README.md
+++ b/graalwasm/graalwasm-micronaut-photon/README.md
@@ -20,13 +20,8 @@ To start the demo, simply run:
 ./mvnw package mn:run
 ```
 
-When the demo runs, open the following URLs in a browser:
-
-- http://localhost:8080/photo/default
-- http://localhost:8080/photo/grayscale
-- http://localhost:8080/photo/colorize
-- http://localhost:8080/photo/fliph
-- http://localhost:8080/photo/flipv
+When the demo runs, open http://localhost:8080/ in a browser.
+To apply a specific effect, navigate to `http://localhost:8080/photo/<effect name>` (e.g., http://localhost:8080/photo/colorize).
 
 To compile the application with GraalVM Native Image, run:
 

--- a/graalwasm/graalwasm-micronaut-photon/README.md
+++ b/graalwasm/graalwasm-micronaut-photon/README.md
@@ -9,7 +9,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application

--- a/graalwasm/graalwasm-spring-boot-photon/README.md
+++ b/graalwasm/graalwasm-spring-boot-photon/README.md
@@ -20,13 +20,9 @@ To start the demo, simply run:
 ./mvnw package spring-boot:run
 ```
 
-When the demo runs, open the following URLs in a browser:
+When the demo runs, open http://localhost:8080/ in a browser.
+To apply a specific effect, navigate to `http://localhost:8080/photo/<effect name>` (e.g., http://localhost:8080/photo/colorize).
 
-- http://localhost:8080/photo/default
-- http://localhost:8080/photo/grayscale
-- http://localhost:8080/photo/colorize
-- http://localhost:8080/photo/fliph
-- http://localhost:8080/photo/flipv
 
 To compile the application with GraalVM Native Image, run:
 

--- a/graalwasm/graalwasm-spring-boot-photon/README.md
+++ b/graalwasm/graalwasm-spring-boot-photon/README.md
@@ -9,7 +9,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application

--- a/graalwasm/graalwasm-spring-boot-photon/pom.xml
+++ b/graalwasm/graalwasm-spring-boot-photon/pom.xml
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <graal.languages.version>24.2.0</graal.languages.version>
+        <graal.languages.version>24.2.1</graal.languages.version>
         <photon.download.url>
             https://raw.githubusercontent.com/fineshopdesign/cf-wasm/dca69477657fe80e36989f1fe7dcc17700d81ee2/packages/photon/src/lib
         </photon.download.url>

--- a/graalwasm/graalwasm-spring-boot-photon/src/main/resources/static/index.html
+++ b/graalwasm/graalwasm-spring-boot-photon/src/main/resources/static/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Effects Demo</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+        }
+        .effects-nav {
+            margin-bottom: 20px;
+        }
+        .effects-nav a {
+            margin: 0 10px;
+            text-decoration: none;
+            color: blue;
+        }
+        .effects-nav a:hover {
+            text-decoration: underline;
+        }
+        #image-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 80vh;
+        }
+        #image-container img {
+            max-width: 100%;
+            max-height: 100%;
+        }
+        #load-time {
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="effects-nav">
+    <a href="#" onclick="changeEffect('default')">Default</a>
+    <a href="#" onclick="changeEffect('flipv')">Flip Vertical</a>
+    <a href="#" onclick="changeEffect('fliph')">Flip Horizontal</a>
+    <a href="#" onclick="changeEffect('solarize')">Solarize</a>
+    <a href="#" onclick="changeEffect('neue')">Neue</a>
+    <a href="#" onclick="changeEffect('lofi')">LoFi</a>
+    <a href="#" onclick="changeEffect('duotone_lilac')">Duotone</a>
+    <a href="#" onclick="changeEffect('ryo')">Ryo</a>
+    <a href="#" onclick="changeEffect('dramatic')">Dramatic</a>
+</div>
+
+<div id="image-container">
+    <img id="effect-image" src="/photo/default" alt="Image with effect">
+</div>
+<div id="load-time"></div>
+
+<script>
+    function changeEffect(effectName) {
+        const startTime = performance.now();
+        const img = document.getElementById('effect-image');
+        img.src = `/photo/${effectName}`;
+        img.onload = () => {
+            const endTime = performance.now();
+            const loadTime = endTime - startTime;
+            document.getElementById('load-time').innerText = `Loaded in ${loadTime.toFixed(2)} ms`;
+        };
+        img.onerror = () => {
+            document.getElementById('load-time').innerText = 'Failed to load image';
+        };
+    }
+
+    // Initially load the image with the default effect
+    document.addEventListener('DOMContentLoaded', (event) => {
+        changeEffect('default');
+    });
+</script>
+
+</body>
+</html>

--- a/graalwasm/graalwasm-starter/README.md
+++ b/graalwasm/graalwasm-starter/README.md
@@ -8,7 +8,7 @@ Install GraalVM for JDK 24 and set the value of `JAVA_HOME` accordingly.
 We recommend using [SDKMAN!](https://sdkman.io/). (For other download options, see [GraalVM Downloads](https://www.graalvm.org/downloads/).)
 
 ```bash
-sdk install java 24-graal
+sdk install java 24.0.1-graal
 ```
 
 ## Run the Application Using Maven

--- a/graalwasm/graalwasm-starter/build.gradle.kts
+++ b/graalwasm/graalwasm-starter/build.gradle.kts
@@ -9,8 +9,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.graalvm.polyglot:polyglot:24.2.0")
-    implementation("org.graalvm.polyglot:wasm:24.2.0")
+    implementation("org.graalvm.polyglot:polyglot:24.2.1")
+    implementation("org.graalvm.polyglot:wasm:24.2.1")
 
     // Use JUnit Jupiter for testing.
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")

--- a/graalwasm/graalwasm-starter/pom.xml
+++ b/graalwasm/graalwasm-starter/pom.xml
@@ -31,12 +31,12 @@
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId> 
-        <version>24.2.0</version>
+        <version>24.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>wasm</artifactId> 
-      <version>24.2.0</version>
+      <version>24.2.1</version>
       <type>pom</type>
     </dependency>
 


### PR DESCRIPTION
Also, add a `dependabot.yml` for automated update PRs and improve the Photon demos a bit (e.g., make them consistent again after merging #36).